### PR TITLE
Removes hallucinations from healing powder.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1336,7 +1336,6 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	if(!M.reagents.has_reagent("stimpak") && !M.reagents.has_reagent("healing_powder")) //should prevent stacking with healing powder and stimpaks
 		M.adjustFireLoss(-3*REM)
 		M.adjustBruteLoss(-3*REM)
-		M.hallucination = max(M.hallucination, 5)
 		. = 1
 	..()
 
@@ -1732,6 +1731,6 @@ datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/M)
 	. = 1
 
 /datum/reagent/medicine/antivenom/overdose_process(mob/living/M)
-	M.adjustToxLoss(4*REM, 0) 
+	M.adjustToxLoss(4*REM, 0)
 	..()
 	. = 1


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Title.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Healing powder simply is not good enough to justify the chance of being stunned for, like, 5-15 seconds depending on the dice roll.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
chungus

## Changelog (necessary)
:cl:
del: healing powder hallucinations
/:cl:
