### PR TITLE
Remove lewd verbs completely

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -619,7 +619,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Play Mojave Radio:</b> <a href='?_src_=prefs;preference=hear_radio'>[(wasteland_toggles & SOUND_RADIO) ? "Enabled":"Disabled"]</a><br>"
 			dat += "<b>Play Lobby Music:</b> <a href='?_src_=prefs;preference=lobby_music'>[(toggles & SOUND_LOBBY) ? "Enabled":"Disabled"]</a><br>"
 			dat += "<b>See Pull Requests:</b> <a href='?_src_=prefs;preference=pull_requests'>[(chat_toggles & CHAT_PULLR) ? "Enabled":"Disabled"]</a><br>"
-			dat += "<b>Allow Lewd Verbs:</b> <a href='?_src_=prefs;preference=verb_consent'>[(wasteland_toggles & VERB_CONSENT) ? "Yes":"No"]</a><br>"
+			
 
 			dat += "<br>"
 
@@ -1703,9 +1703,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("hear_radio")
 					wasteland_toggles ^= SOUND_RADIO
-
-				if("verb_consent")
-					wasteland_toggles ^= VERB_CONSENT
 
 				if("lobby_music")
 					toggles ^= SOUND_LOBBY

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -267,24 +267,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, listen_ooc)()
 /datum/verbs/menu/Settings/listen_ooc/Get_checked(client/C)
 	return C.prefs.chat_toggles & CHAT_OOC
 
-TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, verb_consent)()
-	set name = "Toggle Lewd Verbs"
-	set category = "Preferences"
-	set desc = "Allow Lewd Verbs"
-
-	if (usr && isliving(usr))
-		var/mob/living/L = usr
-		if(L.refactory_period)
-			to_chat(usr, "You need to wait [DisplayTimeText(L.refactory_period * 10, TRUE)] to change your consent setting.")
-			return
 	
-	usr.client.prefs.wasteland_toggles ^= VERB_CONSENT
-	usr.client.prefs.save_preferences()
-	to_chat(usr, "You [(usr.client.prefs.wasteland_toggles & VERB_CONSENT) ? "consent" : "do not consent"] to the use of lewd verbs on your character.")
-	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Allow Lewd Verbs", "[usr.client.prefs.wasteland_toggles & VERB_CONSENT ? "Yes" : "No"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/datum/verbs/menu/Settings/verb_consent/Get_checked(client/C)
-	return C.prefs.wasteland_toggles & VERB_CONSENT
 
 
 TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, listen_looc)()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -119,11 +119,7 @@
 		if(100 to 200)
 			msg += "<span class='warning'>[t_He] [t_is] twitching ever so slightly.</span>\n"
 
-	if(client && client.prefs)
-		if(client.prefs.wasteland_toggles & VERB_CONSENT)
-			msg += "[t_His] player has allowed lewd verbs.\n"
-		else
-			msg += "[t_His] player has not allowed lewd verbs.\n"
+
 
 	var/appears_dead = 0
 	if(stat == DEAD || (has_trait(TRAIT_FAKEDEATH)))


### PR DESCRIPTION
This PR will fully remove lewd verbs from the code. In examine, whether one has enabled lewd verbs or not cannot be seem anymore (as lewd verbs are now fully gone.) In preferences, the ability to toggle lewd verbs has been removed.